### PR TITLE
Fixed missing request body when no file is attached

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,10 +16,12 @@ function fastifyUpload (fastify, options, done) {
   fastify.use(fileUpload(options))
 
   fastify.addHook('preValidation', (request, reply, done) => {
-    if (request.raw && request.raw.files) {
+    if (request.raw) {
       !request.body && (request.body = request.raw.body || {})
-      for (const key in request.raw.files) {
-        request.body[key] = request.raw.files[key]
+      if (request.raw.files) {
+        for (const key in request.raw.files) {
+          request.body[key] = request.raw.files[key]
+        }
       }
     }
     done()


### PR DESCRIPTION
Request body is missing when no file is attached.
Fixed scenarios when request body for other non-file fields are missing when no file is uploaded. 
Attaching a file is now optional.

Case: Multipart Forms can have optional file attachments. req.body was missing so I had to do this
 in handler

    const files = req.raw.files
    // req.body doesn't exist when no file is uploaded so set it for that case
    if (files == null) {
      // Needed to grab req.body for consistency
      req.body = req.raw.body;
    }

