### PR TITLE
Fix typescript error in definition file, patch IncomingMessage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,38 @@
-import { FastifyInstance, FastifyPluginCallback, FastifyPluginOptions, FastifyRequest } from "fastify";
-import { Server } from "http";
+declare module "fastify-file-upload" {
+  import { FastifyInstance, FastifyPluginCallback, FastifyPluginOptions, FastifyRequest } from "fastify";
+  import { Server } from "http";
 
-declare function setMultipart (request: FastifyRequest, payload: any, done: () => void): void;
-declare function fastifyUpload (fastify: FastifyInstance, options: any, done: () => void): void;
+  export function setMultipart(request: FastifyRequest, payload: any, done: () => void): void;
+  export function fastifyUpload(fastify: FastifyInstance, options: any, done: () => void): void;
 
-declare export default (): FastifyPluginCallback<FastifyPluginOptions, Server> => {};
+  const defaultValue: () => FastifyPluginCallback<FastifyPluginOptions, Server>;
+  export default defaultValue
+}
+
+type UploadedFile = {
+  /** file name */
+  name: string;
+  /** A function to move the file elsewhere on your server */
+  mv(path: string, callback: (error: unknown) => void): void;
+  mv(path: string): Promise<void>;
+  /** Encoding type of the file */
+  encoding: string;
+  /** The mimetype of your file */
+  mimetype: string;
+  /** A buffer representation of your file, returns empty buffer in case useTempFiles option was set to true. */
+  data: Buffer;
+  /** A path to the temporary file in case useTempFiles option was set to true. */
+  tempFilePath: string;
+  /** A boolean that represents if the file is over the size limit */
+  truncated: boolean;
+  /** Uploaded size in bytes */
+  size: number;
+  /** MD5 checksum of the uploaded file */
+  md5: string;
+};
+
+declare module "http" {
+  interface IncomingMessage {
+    files?: UploadedFile | UploadedFile[];
+  }
+}


### PR DESCRIPTION
Right now, typescript (v4.5.4) throws an error when trying to use the definition file:


I believe this to be a syntax error. The proposed change fixes that.

I've also included the ImcomingMessage patch (kudos to [flo-sch](https://github.com/flo-sch), he provided his definition here: https://github.com/huangang/fastify-file-upload/pull/12#issuecomment-1015466927)